### PR TITLE
Fix heatmap points disappearing with working intensity extractor

### DIFF
--- a/client/src/views/Home/index.jsx
+++ b/client/src/views/Home/index.jsx
@@ -7,6 +7,8 @@ import HeatmapLayer from './HeatmapLayer'
 import { graphql } from 'react-apollo'
 import gql from 'graphql-tag'
 
+const POINT_INTENSITY = 300;
+
 const listReportsQuery = gql`
   query {
     listReports {
@@ -81,13 +83,16 @@ const Home = ({ data: { loading, listReports } }) => {
         </div>
       </Form>
       <Map center={center} zoom={zoom} onDrag={onDrag} onZoom={onZoom} style={{ height }}>
-        <HeatmapLayer
-          points={listReports && listReports.map(report => [report.lat, report.lng])}
-          longitudeExtractor={m => m[1]}
-          latitudeExtractor={m => m[0]}
-          intensityExtractor={m => parseFloat(m[2])}
-          radius={12}
-        />
+        {listReports &&
+          <HeatmapLayer
+            points={listReports.map(report => [report.lat, report.lng])}
+            longitudeExtractor={m => m[1]}
+            latitudeExtractor={m => m[0]}
+            intensityExtractor={m => POINT_INTENSITY}
+            radius={12}
+            max={POINT_INTENSITY / 100}
+          />
+        }
         <TileLayer
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"


### PR DESCRIPTION
I don't fully understand the intensity extractor concept here, but I do
know that there is no such thing as `m[2]` on the [lat, lng] points we
pass into the heatmap layer.

I've also indented the <HeatmapLayer> component in the conditional for
the brief period before Apollo loads the data.