### PR TITLE
Add info tooltip for points with descriptions

### DIFF
--- a/client/src/views/Home/index.jsx
+++ b/client/src/views/Home/index.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import React, { useState, useEffect } from 'react'
-import { Map, TileLayer } from 'react-leaflet'
+import { CircleMarker, Popup, Map, TileLayer } from 'react-leaflet'
 import { coordsOakland } from 'src/constants'
 import { Button, Form, Header } from 'semantic-ui-react'
 import HeatmapLayer from './HeatmapLayer'
@@ -13,6 +13,7 @@ const listReportsQuery = gql`
       id
       lat
       lng
+      description
     }
   }
 `
@@ -92,6 +93,11 @@ const Home = ({ data: { loading, listReports } }) => {
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
+        { listReports && listReports.filter(r => !!r.description).map(report => (
+          <CircleMarker center={[report.lat, report.lng]} radius={5} weight={0}>
+            { report.description && (<Popup>{ report.description }</Popup>)}
+          </CircleMarker>
+        ))}
       </Map>
 
       <Button color="red" fluid as={Link} to="/report" size="massive">

--- a/client/src/views/Home/index.jsx
+++ b/client/src/views/Home/index.jsx
@@ -95,7 +95,7 @@ const Home = ({ data: { loading, listReports } }) => {
         />
         { listReports && listReports.filter(r => !!r.description).map(report => (
           <CircleMarker center={[report.lat, report.lng]} radius={5} weight={0}>
-            { report.description && (<Popup>{ report.description }</Popup>)}
+            <Popup>{ report.description }</Popup>
           </CircleMarker>
         ))}
       </Map>


### PR DESCRIPTION
Related to: https://github.com/lanelookout/lanelookout/issues/7

Adds info tooltips that pop up when a report description is available on the corresponding heat map point.